### PR TITLE
Optimize defines - Use only relevant defines

### DIFF
--- a/scramble.py
+++ b/scramble.py
@@ -35,8 +35,8 @@ random.shuffle(listGenWords)
 newLines = []
 fileHead = []  ##A list of all YOUR macros
 startFlag=0
-usedDefines = []
 usedKeyWords = []
+usedDefines = []
 
 for line in lines:
     print(line) 
@@ -64,9 +64,15 @@ for line in lines:
 
     newLines.append(line)
 
+##Remove duplicates
+uniqueUsedKeywords = list(dict.fromkeys(usedKeyWords))
+print(uniqueUsedKeywords)
+uniqueUsedDefines = list(dict.fromkeys(usedDefines))
+print(uniqueUsedDefines)
+
 defLines = []  ##This is the list of all new macros
-for i, usedDefine in enumerate(usedDefines):
-    defLines.append("#define " + usedDefine + " " + usedKeyWords[i] + "\n")
+for i, uniqueUsedDefine in enumerate(uniqueUsedDefines):
+    defLines.append("#define " + uniqueUsedDefine + " " + uniqueUsedKeywords[i] + "\n")
 
 with open(file+'Yeet.cpp','w') as f:   ##A new file will be created with suffix 'Yeet'
     for i in fileHead:

--- a/scramble.py
+++ b/scramble.py
@@ -44,8 +44,10 @@ for line in lines:
     else:
         startFlag=1
     if startFlag==1:
-        for i,keyword in enumerate(keywords):
-            line = re.sub(keyword,listGenWords[i],line)  ##This version only substitutes the required keyword
+        found_keywords_in_line = [keyword for keyword in keywords if(keyword in line)]
+        print(found_keywords_in_line)
+        for keyword in found_keywords_in_line:
+            line = re.sub(keyword,listGenWords[keywords.index(keyword)],line)  ##This version only substitutes the required keyword
 
     newLines.append(line)
 

--- a/scramble.py
+++ b/scramble.py
@@ -39,6 +39,7 @@ usedDefines = []
 usedKeyWords = []
 
 for line in lines:
+    print(line) 
     ##Remember //start indicates the start of your actual program (after all of YOUR macros)
     if(line != "//start\n" and startFlag==0):
         fileHead.append(line)
@@ -46,15 +47,15 @@ for line in lines:
     else:
         startFlag=1
     if startFlag==1:
-        found_keywords_in_line = [keyword for keyword in keywords if(keyword in line)]
-        if len(found_keywords_in_line) == 0:
+        foundKeywordsInLine = [keyword for keyword in keywords if(keyword in line)]
+        if len(foundKeywordsInLine) == 0:
             newLines.append(line)
             continue
 
-        for found_keyword_in_line in found_keywords_in_line:
-            usedKeyWords.append(found_keyword_in_line)
+        for foundKeywordInLine in foundKeywordsInLine:
+            usedKeyWords.append(foundKeywordInLine)
 
-        for keyword in found_keywords_in_line:
+        for keyword in foundKeywordsInLine:
             usedDefines.append(listGenWords[keywords.index(keyword)])
             line = re.sub(keyword,listGenWords[keywords.index(keyword)],line)  ##This version only substitutes the required keyword
 
@@ -66,7 +67,6 @@ for line in lines:
 defLines = []  ##This is the list of all new macros
 for i, usedDefine in enumerate(usedDefines):
     defLines.append("#define " + usedDefine + " " + usedKeyWords[i] + "\n")
-    pass
 
 with open(file+'Yeet.cpp','w') as f:   ##A new file will be created with suffix 'Yeet'
     for i in fileHead:

--- a/scramble.py
+++ b/scramble.py
@@ -35,6 +35,7 @@ random.shuffle(listGenWords)
 newLines = []
 fileHead = []  ##A list of all YOUR macros
 startFlag=0
+usedDefines = set()
 
 for line in lines:
     ##Remember //start indicates the start of your actual program (after all of YOUR macros)
@@ -45,9 +46,14 @@ for line in lines:
         startFlag=1
     if startFlag==1:
         found_keywords_in_line = [keyword for keyword in keywords if(keyword in line)]
+        if len(found_keywords_in_line) == 0:
+            newLines.append(line)
+            continue
         print(found_keywords_in_line)
         for keyword in found_keywords_in_line:
+            usedDefines.add(listGenWords[keywords.index(keyword)])
             line = re.sub(keyword,listGenWords[keywords.index(keyword)],line)  ##This version only substitutes the required keyword
+        print(usedDefines)
 
     newLines.append(line)
 

--- a/scramble.py
+++ b/scramble.py
@@ -39,7 +39,6 @@ usedKeyWords = []
 usedDefines = []
 
 for line in lines:
-    print(line) 
     ##Remember //start indicates the start of your actual program (after all of YOUR macros)
     if(line != "//start\n" and startFlag==0):
         fileHead.append(line)
@@ -59,16 +58,11 @@ for line in lines:
             usedDefines.append(listGenWords[keywords.index(keyword)])
             line = re.sub(keyword,listGenWords[keywords.index(keyword)],line)  ##This version only substitutes the required keyword
 
-        print(usedKeyWords)
-        print(usedDefines)
-
     newLines.append(line)
 
 ##Remove duplicates
 uniqueUsedKeywords = list(dict.fromkeys(usedKeyWords))
-print(uniqueUsedKeywords)
 uniqueUsedDefines = list(dict.fromkeys(usedDefines))
-print(uniqueUsedDefines)
 
 defLines = []  ##This is the list of all new macros
 for i, uniqueUsedDefine in enumerate(uniqueUsedDefines):

--- a/scramble.py
+++ b/scramble.py
@@ -35,7 +35,8 @@ random.shuffle(listGenWords)
 newLines = []
 fileHead = []  ##A list of all YOUR macros
 startFlag=0
-usedDefines = set()
+usedDefines = []
+usedKeyWords = []
 
 for line in lines:
     ##Remember //start indicates the start of your actual program (after all of YOUR macros)
@@ -49,17 +50,23 @@ for line in lines:
         if len(found_keywords_in_line) == 0:
             newLines.append(line)
             continue
-        print(found_keywords_in_line)
+
+        for found_keyword_in_line in found_keywords_in_line:
+            usedKeyWords.append(found_keyword_in_line)
+
         for keyword in found_keywords_in_line:
-            usedDefines.add(listGenWords[keywords.index(keyword)])
+            usedDefines.append(listGenWords[keywords.index(keyword)])
             line = re.sub(keyword,listGenWords[keywords.index(keyword)],line)  ##This version only substitutes the required keyword
+
+        print(usedKeyWords)
         print(usedDefines)
 
     newLines.append(line)
 
 defLines = []  ##This is the list of all new macros
-for i,keyword in enumerate(keywords):
-    defLines.append("#define " + listGenWords[i] + " " + keyword + "\n")
+for i, usedDefine in enumerate(usedDefines):
+    defLines.append("#define " + usedDefine + " " + usedKeyWords[i] + "\n")
+    pass
 
 with open(file+'Yeet.cpp','w') as f:   ##A new file will be created with suffix 'Yeet'
     for i in fileHead:


### PR DESCRIPTION
**Features:**
* Optimizes the inserted define macros, so that only those are used, that have respective keywords in the code
* Replacing keywords no longer goes through the entire list of all keywords on each line, but only found ones, which should reduce the runtime

E.g. new example of scrambled code:  
```c++
#include <iostream>

#define yEeeEeT using
#define YEeEEet namespace
#define yEEEeET int
#define yeEEEEt endl
#define YeeEeET cout
#define YEeeEEt return
//start

yEeeEeT YEeEEet std;

yEEEeET main()
{
  yEEEeET a = 0;
  YeeEeET << "Hello World!" << yeEEEEt;
  yEEEeET b = 1;
  YEeeEEt 0;
}
```

Let me know what you think!